### PR TITLE
feat: manage daily entries by entry id

### DIFF
--- a/src/components/daily/Daily.js
+++ b/src/components/daily/Daily.js
@@ -99,9 +99,28 @@ const Daily = ({ setTotalCalories, selectedDate }) => {
     [setTotalCalories, selectedDate]
   );
 
-  const onClickEdit = useCallback((foodId, foodName) => {
-    setSelectedEntry(foodId);
-    setSelectedEntryName(foodName);
+  const onClickUpdateAmount = useCallback(
+    async (entryId, amount) => {
+      try {
+        await API.put(`/daily-entries/${entryId}`, { amount });
+        await fetchDailyConsumption(
+          setDailyData,
+          setCalorieProgress,
+          setLoading,
+          setError,
+          setTotalCalories,
+          selectedDate
+        );
+      } catch (err) {
+        setError(err.response?.data?.message || "Failed to update entry");
+      }
+    },
+    [setTotalCalories, selectedDate]
+  );
+
+  const onClickEdit = useCallback((group) => {
+    setSelectedEntry(group);
+    setSelectedEntryName(group?.name || "");
     setPopupOpen(true);
   }, []);
 
@@ -219,11 +238,12 @@ const Daily = ({ setTotalCalories, selectedDate }) => {
         />
       </div>
       <Popup isOpen={isPopupOpen} onClose={() => setPopupOpen(false)}>
-        <h2>Remove daily entries for {selectedEntryName}</h2>
+        <h2>Manage entries for {selectedEntryName}</h2>
         <PopupList
           dailyData={dailyData}
           selectedEntry={selectedEntry}
           onClickDelete={onClickDelete}
+          onClickUpdateAmount={onClickUpdateAmount}
         />
       </Popup>
 

--- a/src/components/daily/DailyList.js
+++ b/src/components/daily/DailyList.js
@@ -8,7 +8,10 @@ const DailyList = ({ dailyData, onClickEdit, selectedDate }) => {
     <ul className="food-list daily-list">
       {dailyData.entries.length > 0 ? (
         dailyData.entries.map((entry) => (
-          <li key={entry.food_id} className="food-item">
+          <li
+            key={`${entry.entry_type}:${entry.entry_type === "food" ? entry.food_id : entry.recipe_id}`}
+            className="food-item"
+          >
             <div className="food-name">
               {entry.amount}x <strong>{entry.name}</strong>
             </div>
@@ -21,7 +24,16 @@ const DailyList = ({ dailyData, onClickEdit, selectedDate }) => {
               {parseFloat(entry.total_kcal.toFixed(1))} kcal
             </div>
             <div className="food-actions">
-              <button onClick={() => onClickEdit(entry.food_id, entry.name)}>
+              <button
+                onClick={() =>
+                  onClickEdit({
+                    entry_type: entry.entry_type,
+                    food_id: entry.food_id,
+                    recipe_id: entry.recipe_id,
+                    name: entry.name,
+                  })
+                }
+              >
                 <FontAwesomeIcon icon={faEdit} />
               </button>
             </div>

--- a/src/components/daily/PopupList.js
+++ b/src/components/daily/PopupList.js
@@ -1,23 +1,68 @@
 import React from "react";
+import { useState } from "react";
 import "../css/global.css";
 
-const PopupList = ({ dailyData, selectedEntry, onClickDelete }) => {
+const PopupList = ({
+  dailyData,
+  selectedEntry,
+  onClickDelete,
+  onClickUpdateAmount,
+}) => {
+  const [amountById, setAmountById] = useState({});
+
+  const getEntryName = (entry) =>
+    entry.entry_type === "food"
+      ? entry.Food?.name || "Unknown Food"
+      : entry.Recipe?.name || "Unknown Recipe";
+
+  const matchesGroup = (entry) => {
+    if (!selectedEntry) return false;
+    if (selectedEntry.entry_type !== entry.entry_type) return false;
+    if (entry.entry_type === "food") return entry.food_id === selectedEntry.food_id;
+    if (entry.entry_type === "recipe")
+      return entry.recipe_id === selectedEntry.recipe_id;
+    return false;
+  };
+
+  const entries = dailyData.entriesSeperate.filter(matchesGroup);
+
   return (
     <ul className="food-list popup-list">
-      {dailyData.entriesSeperate.filter(
-        (entry) => entry.food_id === selectedEntry
-      ).length > 0 ? (
-        dailyData.entriesSeperate
-          .filter((entry) => entry.food_id === selectedEntry)
-          .map((entry) => (
+      {entries.length > 0 ? (
+        entries.map((entry) => (
             <li key={entry.id} className="food-item">
               <div className="food-name">
-                {entry.amount}x <strong>{entry.name}</strong>
+                {entry.amount}x <strong>{getEntryName(entry)}</strong>
               </div>
               <div className="food-kcal">
                 {parseFloat(entry.total_kcal.toFixed(1))} kcal
               </div>
-              <div className="food-actions">
+              <div className="food-actions" style={{ gap: 8, display: "flex" }}>
+                <input
+                  type="number"
+                  min="0.01"
+                  step="0.01"
+                  value={
+                    amountById[entry.id] !== undefined
+                      ? amountById[entry.id]
+                      : entry.amount
+                  }
+                  onChange={(e) =>
+                    setAmountById((prev) => ({
+                      ...prev,
+                      [entry.id]: e.target.value,
+                    }))
+                  }
+                  style={{ width: 110 }}
+                  aria-label="Update amount"
+                />
+                <button
+                  onClick={() =>
+                    onClickUpdateAmount(entry.id, amountById[entry.id] ?? entry.amount)
+                  }
+                >
+                  Save
+                </button>
                 <button onClick={() => onClickDelete(entry.id)}>Delete</button>
               </div>
             </li>


### PR DESCRIPTION
Update dashboard to open a manage popup per food/recipe group and allow saving a new amount or deleting individual logged entries (by entry.id) for cleaner corrections.